### PR TITLE
fix original issue #12 with Hjson::Value testing functions named `is_*`

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,6 +319,24 @@ Hjson::Value GetConfig(const char *szInputConfig) {
 }
 ```
 
+# testing Hjson values
+
+A set of convenience member functions in `Hjson::Value` whose name
+start with `is_` enables quick extraction from an `Hjson::Value`. For
+example, to test that some `Hjson::Value hjv;` is a map with exactly
+two members `x` and `y` associated to floating point numbers you could code:
+
+```cpp
+  HJson::Value hjv = Hjson::Unmarshal(sampleText.c_str(), sampleText.size());
+  std::size_t mapsiz=0;
+  double x=0, y=0;
+  if (hjv.is_map(&mapsiz) && mapsiz == 2
+      && hjv.is_map_with_key("x") &&  hjv.is_map_with_key("y")
+      && hjv["x"].is_double(&x) &&  hjv["y"].is_double(&y)
+      do_something(x,y);
+```
+
+
 # History
 
 [see releases](https://github.com/hjson/hjson-cpp/releases)

--- a/include/hjson/hjson.h
+++ b/include/hjson/hjson.h
@@ -188,6 +188,7 @@ public:
   bool is_map(void) const noexcept;
   bool is_map(std::size_t*psiz) const noexcept;
   bool is_map_with_key(const std::string& key) const noexcept;
+  bool is_map_with_key(const char* key) const noexcept;
 };
 
 

--- a/include/hjson/hjson.h
+++ b/include/hjson/hjson.h
@@ -169,6 +169,25 @@ public:
   double to_double() const;
   std::int64_t to_int64() const;
   std::string to_string() const;
+
+  // Test and perhaps gives size or value thru pointer, ignored if it
+  // is the nullptr; these member functions never throw exceptions.
+  bool is_undefined(void) const noexcept;
+  bool is_null(void) const noexcept;
+  bool is_bool(void) const noexcept;
+  bool is_bool(bool*pval) const noexcept;
+  bool is_double(void) const noexcept;
+  bool is_double(double *pval) const noexcept;
+  bool is_int64(void) const noexcept;
+  bool is_int64(std::int64_t*pval) const noexcept;
+  bool is_string(void) const noexcept;
+  bool is_string(std::size_t*psiz) const noexcept;
+  bool is_string(std::string*pval) const noexcept;
+  bool is_vector(void) const noexcept;
+  bool is_vector(std::size_t*psiz) const noexcept;
+  bool is_map(void) const noexcept;
+  bool is_map(std::size_t*psiz) const noexcept;
+  bool is_map_with_key(const std::string& key) const noexcept;
 };
 
 

--- a/src/hjson_value.cpp
+++ b/src/hjson_value.cpp
@@ -1244,5 +1244,13 @@ Value::is_map_with_key(const std::string& key) const noexcept {
   };
   return false;
 }
+bool
+Value::is_map_with_key(const char* key) const noexcept {
+  if (prv->type == ValueImpl::IMPL_MAP && key) {
+    std::string keystr(key);
+    return is_map_with_key(keystr);
+  };
+  return false;
+}
 
 } // end namespace Hjson

--- a/src/hjson_value.cpp
+++ b/src/hjson_value.cpp
@@ -1105,4 +1105,144 @@ Value Merge(const Value base, const Value ext) {
 }
 
 
+////////////////////////////////////////////////////////////////
+
+bool
+Value::is_undefined(void) const noexcept {
+  return prv->type == ValueImpl::IMPL_UNDEFINED;
 }
+
+
+bool
+Value::is_null(void) const  noexcept {
+  return prv->type == ValueImpl::IMPL_HJSON_NULL;
+}
+
+
+//// testing booleans
+
+bool
+Value::is_bool(void) const noexcept {
+  return prv->type == ValueImpl::IMPL_BOOL;
+}
+
+
+bool
+Value::is_bool(bool *pval) const noexcept {
+  if (prv->type == ValueImpl::IMPL_BOOL) {
+    if (pval != nullptr)
+      *pval = prv->b;
+    return true;
+  }
+  return false;
+}
+
+//// testing doubles
+
+bool
+Value::is_double(void) const noexcept {
+  return prv->type == ValueImpl::IMPL_DOUBLE;
+}
+
+
+bool
+Value::is_double(double *pval) const noexcept {
+  if (prv->type == ValueImpl::IMPL_DOUBLE) {
+    if (pval != nullptr)
+      *pval = prv->d;
+    return true;
+  }
+  return false;
+}
+
+
+//// testing int64-s
+
+bool
+Value::is_int64(void) const noexcept {
+  return prv->type == ValueImpl::IMPL_INT64;
+}
+
+bool
+Value::is_int64(std::int64_t*pval) const noexcept {
+  if (prv->type == ValueImpl::IMPL_INT64) {
+    if (pval)
+      *pval = prv->i;
+    return true;
+  }
+  return false;
+}
+
+
+//// testing string-s
+
+bool
+Value::is_string(void) const noexcept {
+  return prv->type == ValueImpl::IMPL_STRING;
+}
+
+bool
+Value::is_string(std::size_t*psiz) const noexcept {
+  if (prv->type == ValueImpl::IMPL_STRING) {
+    if (psiz)
+      *psiz = ((std::string*)prv->p)->size();
+    return true;
+  };
+  return false;
+}
+
+bool
+Value::is_string(std::string*pval) const noexcept {
+  if (prv->type == ValueImpl::IMPL_STRING) {
+    if (pval)
+      *pval = *((std::string*)prv->p);
+    return true;
+  };
+  return false;
+}
+
+
+//// testing vector-s
+
+bool
+Value::is_vector(void) const noexcept {
+  return prv->type == ValueImpl::IMPL_VECTOR;
+}
+
+bool
+Value::is_vector(std::size_t*psiz) const noexcept {
+  if (prv->type == ValueImpl::IMPL_VECTOR) {
+    if (psiz)
+      *psiz =  ((ValueVec*)prv->p)->size();
+    return true;
+  }
+  return false;
+}
+
+
+/// testing map-s
+
+bool
+Value::is_map(void) const noexcept {
+  return prv->type == ValueImpl::IMPL_MAP;
+}
+
+bool
+Value::is_map(std::size_t*psiz) const noexcept {
+  if (prv->type == ValueImpl::IMPL_MAP) {
+    if (psiz)
+      *psiz = ((ValueVecMap*)prv->p)->m.size();
+    return true;
+  };
+  return false;
+}
+
+bool
+Value::is_map_with_key(const std::string& key) const noexcept {
+  if (prv->type == ValueImpl::IMPL_MAP) {
+    return ((ValueVecMap*)prv->p)->m.find(key) != ((ValueVecMap*)prv->p)->m.end();
+  };
+  return false;
+}
+
+} // end namespace Hjson


### PR DESCRIPTION
This adds safe testing functions in `Hjson::Value` related to [issue #12](https://github.com/hjson/hjson-cpp/issues/22)

Such code is needed in http://refpersys.org/

Regards.

-- 

Basile Starynkevitch (France) http://starynkevitch.net/Basile/
<basile@starynkevitch.net>