### PR TITLE
Include cstdint in hjson.h

### DIFF
--- a/include/hjson/hjson.h
+++ b/include/hjson/hjson.h
@@ -1,6 +1,7 @@
 #ifndef HJSON_AFOWENFOWANEFWOAFNLL
 #define HJSON_AFOWENFOWANEFWOAFNLL
 
+#include <cstdint>
 #include <string>
 #include <memory>
 #include <map>


### PR DESCRIPTION
Needed in gcc 13. Earlier versions of gcc (and all other tested compilers) were less strict.