### PR TITLE
Add override flag to MapProxy destructor

### DIFF
--- a/include/hjson/hjson.h
+++ b/include/hjson/hjson.h
@@ -367,7 +367,7 @@ private:
   MapProxy(Value&&);
 
 public:
-  ~MapProxy();
+  ~MapProxy() override;
   MapProxy& operator =(const MapProxy&);
   MapProxy& operator =(const Value&);
   MapProxy& operator =(Value&&);


### PR DESCRIPTION
New compilers will issue a warning if a destructor that inherits from a class does not have the override keyword. 