### PR TITLE
Improvements on HJson creation

### DIFF
--- a/include/hjson/hjson.h
+++ b/include/hjson/hjson.h
@@ -278,7 +278,6 @@ public:
   // Hjson::type_mismatch if this Value is of any other type than Vector or
   // Undefined.
   void push_back(const Value&);
-  void push_back(Value&&);
 
   // -- Map specific functions
   // Get key by its zero-based insertion index. Throws
@@ -295,9 +294,14 @@ public:
   const Value& at(const char *key) const;
   Value& at(const char *key);
 
+#if __cplusplus >= 201703L
+  // These are functions available in C++17 and greater only
+  // This function will add a value to a vector without a copy
+  void push_back(Value&&);
   // This function can insert a value into the map without an allocation
   void insert(const std::string&key, Value&&);
-  
+#endif // __cplusplus >= 201703L
+
   // Iterations are always done in alphabetical key order. Returns a default
   // constructed iterator if this Value is of any other type than Map.
   std::map<std::string, Value>::iterator begin();

--- a/include/hjson/hjson.h
+++ b/include/hjson/hjson.h
@@ -278,6 +278,7 @@ public:
   // Hjson::type_mismatch if this Value is of any other type than Vector or
   // Undefined.
   void push_back(const Value&);
+  void push_back(Value&&);
 
   // -- Map specific functions
   // Get key by its zero-based insertion index. Throws
@@ -293,6 +294,10 @@ public:
   Value& at(const std::string& key);
   const Value& at(const char *key) const;
   Value& at(const char *key);
+
+  // This function can insert a value into the map without an allocation
+  void insert(const std::string&key, Value&&);
+  
   // Iterations are always done in alphabetical key order. Returns a default
   // constructed iterator if this Value is of any other type than Map.
   std::map<std::string, Value>::iterator begin();

--- a/include/hjson/hjson.h
+++ b/include/hjson/hjson.h
@@ -367,7 +367,7 @@ private:
   MapProxy(Value&&);
 
 public:
-  ~MapProxy();
+  ~MapProxy() override;
   MapProxy& operator =(const MapProxy&);
   MapProxy& operator =(const Value&);
   MapProxy& operator =(Value&&);

--- a/src/hjson_value.cpp
+++ b/src/hjson_value.cpp
@@ -347,6 +347,7 @@ Value& Value::at(const char *name) {
   return at(std::string(name));
 }
 
+#if __cplusplus >= 201703L
 void Value::insert(const std::string&key, Value&& other)
 {
   switch (prv->type)
@@ -361,6 +362,7 @@ void Value::insert(const std::string&key, Value&& other)
     throw type_mismatch("Must be of type Map for that operation.");
   }
 }
+#endif // __cplusplus >= 201703L
   
 
 const Value Value::operator[](const std::string& name) const {
@@ -1341,6 +1343,7 @@ void Value::push_back(const Value& other) {
   prv->v->push_back(other);
 }
 
+#if __cplusplus >= 201703L
 void Value::push_back(Value&& other) {
   if (prv->type == Type::Undefined) {
     prv->~ValueImpl();
@@ -1352,6 +1355,7 @@ void Value::push_back(Value&& other) {
 
   prv->v->push_back(std::move(other));
 }
+#endif // __cplusplus >= 201703L
 
 
 void Value::move(int from, int to) {

--- a/src/hjson_value.cpp
+++ b/src/hjson_value.cpp
@@ -347,6 +347,21 @@ Value& Value::at(const char *name) {
   return at(std::string(name));
 }
 
+void Value::insert(const std::string&key, Value&& other)
+{
+  switch (prv->type)
+  {
+  case Type::Undefined:
+    throw index_out_of_bounds("Key not found.");
+  case Type::Map:
+    try {
+      prv->m->m.insert_or_assign(key, std::move(other));
+    } catch(const std::out_of_range&) {}    
+  default:
+    throw type_mismatch("Must be of type Map for that operation.");
+  }
+}
+  
 
 const Value Value::operator[](const std::string& name) const {
   if (prv->type == Type::Undefined) {
@@ -1324,6 +1339,18 @@ void Value::push_back(const Value& other) {
   }
 
   prv->v->push_back(other);
+}
+
+void Value::push_back(Value&& other) {
+  if (prv->type == Type::Undefined) {
+    prv->~ValueImpl();
+    // Recreate the private object using the same memory block.
+    new(&(*prv)) ValueImpl(Type::Vector);
+  } else if (prv->type != Type::Vector) {
+    throw type_mismatch("Must be of type Undefined or Vector for that operation.");
+  }
+
+  prv->v->push_back(std::move(other));
 }
 
 

--- a/src/hjson_value.cpp
+++ b/src/hjson_value.cpp
@@ -353,11 +353,15 @@ void Value::insert(const std::string&key, Value&& other)
   switch (prv->type)
   {
   case Type::Undefined:
-    throw index_out_of_bounds("Key not found.");
+    prv->~ValueImpl();
+    // Recreate the private object using the same memory block.
+    new(&(*prv)) ValueImpl(Type::Map);
+    // Fall through
   case Type::Map:
     try {
       prv->m->m.insert_or_assign(key, std::move(other));
     } catch(const std::out_of_range&) {}    
+    return;
   default:
     throw type_mismatch("Must be of type Map for that operation.");
   }


### PR DESCRIPTION
This change adds functions for insertion into the map and push_back into vector that use r-value references, allowing for functions that build HJson::Value recursively to skip allocations and copies. 