### PR TITLE
Modify variable name to avoid ODR violations with LTO

### DIFF
--- a/src/hjson_parsenumber.cpp
+++ b/src/hjson_parsenumber.cpp
@@ -13,7 +13,7 @@
 namespace Hjson {
 
 
-struct Parser {
+struct NumberParser {
   const unsigned char *data;
   size_t dataSize;
   int indexNext;
@@ -72,7 +72,7 @@ static bool _parseInt(std::int64_t *pNumber, const char *pCh, size_t nCh) {
 }
 
 
-static bool _next(Parser *p) {
+static bool _next(NumberParser *p) {
   // get the next character.
   if (p->indexNext < p->dataSize) {
     p->ch = p->data[p->indexNext++];
@@ -91,7 +91,7 @@ static bool _next(Parser *p) {
 
 // Parse a number value. The parameter "text" must be zero terminated.
 bool tryParseNumber(Value *pValue, const char *text, size_t textSize, bool stopAtNext) {
-  Parser p = {
+  NumberParser p = {
     (const unsigned char*) text,
     textSize,
     0,


### PR DESCRIPTION
* A different compilation unit hjson_decode also defines hjson::Parser which would conflict with the other definition in hjson_parsenumber. Modifying the variable name in hjson_parsenumber is the path least resistance with only three mentions.
* As this isn't a part of any public interface this should be only cosmetic for non LTO applications.

You can see the warning with GCC if you enable shared libraries, add warnings for odr and enable lto in flags. 

 `cmake -DCMAKE_CXX_COMPILER=g++ -DCMAKE_CXX_FLAGS="-Wodr -flto" -DBUILD_SHARED_LIBS=ON -B build && cmake --build build`

```
/home/ask/sources/hjson-cpp/src/hjson_decode.cpp:20:7: warning: type ‘struct Parser’ violates the C++ One Definition Rule [-Wodr]
   20 | class Parser {
      |       ^
/home/ask/sources/hjson-cpp/src/hjson_parsenumber.cpp:16:8: note: a different type is defined in another translation unit
   16 | struct Parser {
      |        ^
/home/ask/sources/hjson-cpp/src/hjson_decode.cpp:26:18: note: the first difference of corresponding definitions is field ‘opt’
   26 |   DecoderOptions opt;
      |                  ^
/home/ask/sources/hjson-cpp/src/hjson_parsenumber.cpp:16:8: note: a type with different number of fields is defined in another translation unit
   16 | struct Parser {
      |        ^
```